### PR TITLE
A: http://www.eldiariomontanes.es/

### DIFF
--- a/easylistspanish/easylistspanish_specific_block.txt
+++ b/easylistspanish/easylistspanish_specific_block.txt
@@ -277,3 +277,4 @@ $websocket,domain=descargasnsn.com
 ||exabytetv.info/wp-content/plugins/wp-adblock-dedect/
 ||motociclismo.es/js/compiled_blockadblock_15.js
 ||noticiasdelaciencia.com/libs_oss/adblock/
+||static.vocento.com/adbd/


### PR DESCRIPTION
They're using an anti-adblocker script: https://imgur.com/a/qzQdG. Probably affects other pages from Vocento.

Example: `http://www.eldiariomontanes.es/sociedad/grupo-senderistas-despena-20171116112707-nt.html`

I wanted to link here the post on the forum but it's pending validation so I can't.