### PR TITLE
A: www.gnula.cc

### DIFF
--- a/easylistspanish/easylistspanish_specific_hide.txt
+++ b/easylistspanish/easylistspanish_specific_hide.txt
@@ -829,7 +829,7 @@ seriesdanko.to##span[style="font-weight:bold; cursor:pointer; text-decoration:un
 sailingzona.com##td[style="color:#666666; font-size:11px; padding:2px;"]
 fitnesszona.com##td[style="font-family:Arial, Helvetica, sans-serif;font-size:9px;color:#efefef"]
 wapa.pe##div[class^="mol-publicidad"]
-uqload.com##.drts
+uqload.com,gnula.cc,powvibeo.cc,slreamplay.cc##.drts
 noticiacristiana.com##a[href='http://iglesiasegura.com/']
 sport.es##div[data-item-syndicated="true"]
 jkanime.net,cuevana3.video,2conv.com,pelisplus.video,animeblix.com,gnula.se,flvto.biz,vidoza.net,doramasmp4.com##iframe[style*="z-index: 2147483647"]


### PR DESCRIPTION
@jabonsolo I've adjusted filter from: `uqload.com##.drts` to `uqload.com,gnula.cc,powvibeo.cc,slreamplay.cc##.drts` in order to hide popup messages on [gnula.cc](https://www.gnula.cc/ver-episode/outlander-3x9/)

`gnula.cc,powvibeo.cc,slreamplay.cc##.drts` only didn't work, unless is `uqload.com,gnula.cc,powvibeo.cc,slreamplay.cc##.drts` OR `##div[class^="drts"]` 
OR blocking the domains: `||centent.slreamplay.cc^` + `||rontent.powvibeo.cc^`

Please feel free to adjust it accordingly.
<img width="1014" alt="gc1" src="https://user-images.githubusercontent.com/57706597/124306116-41156380-db66-11eb-8d66-df65a5c5a353.png">
<img width="997" alt="gc3" src="https://user-images.githubusercontent.com/57706597/124306130-483c7180-db66-11eb-8fc3-eb8ee0b1806e.png">
<img width="981" alt="gc4" src="https://user-images.githubusercontent.com/57706597/124306144-4b376200-db66-11eb-8a30-8d7017e0bfdf.png">
