### PR TITLE
A: hdfull.in

### DIFF
--- a/easylistspanish/easylistspanish_specific_block.txt
+++ b/easylistspanish/easylistspanish_specific_block.txt
@@ -622,3 +622,5 @@ $third-party,xmlhttprequest,domain=animeflv.net|descargasnsn.com|divxatope.com|d
 ||midastouchrt.com^$popup,third-party=animefenix.com
 ||cuntempire.com^$popup,third-party=animefenix.com
 /popup-maker/$script,domain=diariotextual.com
+||rontent.powvibeo.cc^$popup,script
+||centent.slreamplay.cc^$popup,script


### PR DESCRIPTION
Filters to block popup on [hdfull.in](https://hdfull.in/ ) (login required) and also work for [gnula.cc](https://www.gnula.cc/)
Manu and I tried with snippet filters: `$#abort-current-inline-script` also `abort-on-property-read/write` we got hit of them but it doesn't prevent the popup from opening still.
Each player has their own script to open popups. Filters with $popups didn't prevent popups either. The ones that worked so far were:
```
||rontent.powvibeo.cc^$popup,script
||centent.slreamplay.cc^$popup,script
```

Please feel free to adjust filters accordingly.