### PR TITLE
A: skdesu.com

### DIFF
--- a/easylistspanish/easylistspanish_specific_hide.txt
+++ b/easylistspanish/easylistspanish_specific_hide.txt
@@ -967,3 +967,4 @@ kairosweb.com##div[class*="banner-"]
 kairosweb.com##.spu-bg
 kairosweb.com##.spu-box
 poki.com##div[class^="Advertisement__AdvertisementContainer"]
+skdesu.com##.code-block[style^="margin: 20px auto;"]


### PR DESCRIPTION
Filter for hiding placeholders on [Skdesu](https://skdesu.com/es/las-14-enfermedades-mas-contagiosas-y-mortales-de-japon/) and all the other content subpages. 

Hiding filter: `skdesu.com##.code-block[style^="margin: 20px auto;"]`

Explanation: I was not able to block just the class because of a self promo, on the other hand all the placeholders within tha page had the same style. 

Screenshot of the page: 
<img width="321" alt="Screenshot 2021-09-21 at 23 07 23" src="https://user-images.githubusercontent.com/65717387/134272690-aeefd338-2096-495d-9974-4ec0791d6852.png">

Self promo:
<img width="1429" alt="Screenshot 2021-09-21 at 23 13 22" src="https://user-images.githubusercontent.com/65717387/134272821-f9bb1678-c804-4c0e-b251-d077129f694a.png">
 
