### PR TITLE
A: pelisplus.so

### DIFF
--- a/easylistspanish/easylistspanish_adservers_popup.txt
+++ b/easylistspanish/easylistspanish_adservers_popup.txt
@@ -53,3 +53,4 @@
 ||dlxrlc2ni2.com^$popup,third-party
 ||oackoubs.com^$popup,third-party
 ||adfpoint.com^$popup,third-party
+||repelis.id^$popup,third-party


### PR DESCRIPTION
Filter: `||repelis.id^$popup,third-party` to block redirect popups on [pelisplus.so](https://pelisplus.so/)

**Sample URL:** https://pelisplus.so/los-expedientes-secretos-x/temporada-3/capitulo-23

**Steps to reproduce:**
Connect to VPN location: **Spain - Barcelona - 2**
Select **Streamsb** or **Streamtape** or **Fember** or **Hydrax** server option and click on the play button.

`||ptilytiga.com^$popup,third-party` added on [PR/183](https://github.com/easylist/easylistspanish/pull/183/files) would also block popups on **Streamtape** server option.

Also created [PR/687](https://github.com/abp-filters/abp-filters-anti-cv/pull/687) n the anti-cv list to block popup messages.

<img width="1394" alt="cm" src="https://user-images.githubusercontent.com/57706597/134576440-d29e3d7b-90ac-4a16-a546-a3ff3f041859.png">
<img width="1355" alt="bm" src="https://user-images.githubusercontent.com/57706597/134576457-ab1d1ed8-ae97-47cf-8f5f-ed8f4b0d6316.png">

