### PR TITLE
A: series24.cc

### DIFF
--- a/easylistspanish/easylistspanish_specific_block.txt
+++ b/easylistspanish/easylistspanish_specific_block.txt
@@ -624,3 +624,4 @@ $third-party,xmlhttprequest,domain=animeflv.net|descargasnsn.com|divxatope.com|d
 /popup-maker/$script,domain=diariotextual.com
 ||rontent.powvibeo.cc^$popup,script
 ||centent.slreamplay.cc^$popup,script
+||maholinoticed.com^$script


### PR DESCRIPTION
Filters to block popups and refers on [series24](https://www.series24.cc/ver-serie-online/the-crimson-rivers-3x6/).

Due to the issue report [issue report](https://reports.adblockplus.org/7189262d-e74d-43e1-8c87-b2adbb4e697b#tab=screenshot) . I was able to find the script that block not just the popups but all the referrals after clicking the other episodes. 

Proposed blocking filter : `||maholinoticed.com^$script`

Screenshots can be found at the page mentioned above. 