### PR TITLE
A: rtvc.es

### DIFF
--- a/easylistspanish/easylistspanish_specific_block.txt
+++ b/easylistspanish/easylistspanish_specific_block.txt
@@ -624,3 +624,4 @@ $third-party,xmlhttprequest,domain=animeflv.net|descargasnsn.com|divxatope.com|d
 /popup-maker/$script,domain=diariotextual.com
 ||rontent.powvibeo.cc^$popup,script
 ||centent.slreamplay.cc^$popup,script
+||rtvc.es/storage/*/249.js


### PR DESCRIPTION
Filter for blocking ads in the following domain [rtvc](https://rtvc.es/)  and subdomains, example [rtvc subdomain](https://rtvc.es/covid-19/)

The issue came out from: [issue report](https://reports.adblockplus.org/50a74778-8c8d-4b75-9fb2-eb6367e01d61#tab=screenshot)

Proposed blocking filter: `||rtvc.es/storage/*/249.js`

Screenshots from main page and subpage: 
<img width="1440" alt="Screenshot 2021-09-24 at 12 29 40" src="https://user-images.githubusercontent.com/65717387/134701831-81cf7cd1-5545-41a1-9191-f4b4f0225e0b.png">
<img width="1440" alt="Screenshot 2021-09-24 at 12 30 02" src="https://user-images.githubusercontent.com/65717387/134701876-fffdb65b-33c0-4dab-a307-1b4cd99dfb71.png">


