### PR TITLE
A: elcontribuyente.mx

### DIFF
--- a/easylistspanish/easylistspanish_specific_hide.txt
+++ b/easylistspanish/easylistspanish_specific_hide.txt
@@ -968,3 +968,5 @@ kairosweb.com##.spu-bg
 kairosweb.com##.spu-box
 poki.com##div[class^="Advertisement__AdvertisementContainer"]
 skdesu.com##.code-block[style^="margin: 20px auto;"]
+elcontribuyente.mx##picture[class^="aligncenter size-full wp-image-"]
+elcontribuyente.mx##.lx_close_button

--- a/easylistspanish/easylistspanish_specific_hide.txt
+++ b/easylistspanish/easylistspanish_specific_hide.txt
@@ -968,5 +968,5 @@ kairosweb.com##.spu-bg
 kairosweb.com##.spu-box
 poki.com##div[class^="Advertisement__AdvertisementContainer"]
 skdesu.com##.code-block[style^="margin: 20px auto;"]
-elcontribuyente.mx##picture[class^="aligncenter size-full wp-image-"]
-elcontribuyente.mx##.lx_close_button
+elcontribuyente.mx##a[onclick*="Publicidad"]
+elcontribuyente.mx#?#div:-abp-has(a[title="Clickio"])


### PR DESCRIPTION
Hiding rules for [elcontribuyente.mx](https://www.elcontribuyente.mx/2020/06/las-redes-factureras-podrian-presentar-sanciones-penales-de-hasta-9-anos-de-prision-por-perjuicio-fiscal/)

`elcontribuyente.mx##picture[class^="aligncenter size-full wp-image-"]` hides Thomson Reuters ad on the top
`elcontribuyente.mx##.lx_close_button` - hides left close label

<img width="1203" alt="dfh" src="https://user-images.githubusercontent.com/57706597/134740057-33ccd7b3-ae98-46ef-aaaa-f81868eb53b1.png">

> Tabbola feed ads seem self-promo; they link to its domain.

