### PR TITLE
A: alcalorpolitico.com

### DIFF
--- a/easylistspanish/easylistspanish_specific_block.txt
+++ b/easylistspanish/easylistspanish_specific_block.txt
@@ -624,3 +624,4 @@ $third-party,xmlhttprequest,domain=animeflv.net|descargasnsn.com|divxatope.com|d
 /popup-maker/$script,domain=diariotextual.com
 ||rontent.powvibeo.cc^$popup,script
 ||centent.slreamplay.cc^$popup,script
+/imagenes/imagenespublicidad/*$image,domain=alcalorpolitico.com

--- a/easylistspanish/easylistspanish_specific_block.txt
+++ b/easylistspanish/easylistspanish_specific_block.txt
@@ -624,4 +624,4 @@ $third-party,xmlhttprequest,domain=animeflv.net|descargasnsn.com|divxatope.com|d
 /popup-maker/$script,domain=diariotextual.com
 ||rontent.powvibeo.cc^$popup,script
 ||centent.slreamplay.cc^$popup,script
-/imagenes/imagenespublicidad/*$image,domain=alcalorpolitico.com
+/imagenespublicidad/$image,domain=alcalorpolitico.com

--- a/easylistspanish/easylistspanish_specific_hide.txt
+++ b/easylistspanish/easylistspanish_specific_hide.txt
@@ -968,3 +968,4 @@ kairosweb.com##.spu-bg
 kairosweb.com##.spu-box
 poki.com##div[class^="Advertisement__AdvertisementContainer"]
 skdesu.com##.code-block[style^="margin: 20px auto;"]
+alcalorpolitico.com##div[id^="Bannerprincipal"]


### PR DESCRIPTION
Adding rules for [alcalorpolitico.com](https://www.alcalorpolitico.com/informacion/captan-en-video-asalto-a-coppel-de-naolinco-321490.html)

`/imagenes/imagenespublicidad/*$image,domain=alcalorpolitico.com` - Block ads on the top and right side

<img width="1209" alt="acp" src="https://user-images.githubusercontent.com/57706597/134741578-d87a726d-1b13-4618-bcbc-675a39ab263d.png">


`alcalorpolitico.com##div[id^="Bannerprincipal"]` - Hides placeholder on the [home page](https://www.alcalorpolitico.com/edicion/inicio.html)


<img width="1144" alt="acpb" src="https://user-images.githubusercontent.com/57706597/134741444-dfe1a74a-c3a1-47b3-ae53-7c3104b8ac81.png">


> Tabbola feed ads seem self-promo; they link to its domain.