### PR TITLE
A: ver-television.online

### DIFF
--- a/easylistspanish/easylistspanish_thirdparty.txt
+++ b/easylistspanish/easylistspanish_thirdparty.txt
@@ -16,5 +16,4 @@
 ||jsc.adgage.es^$third-party
 ||cdn.zxclan.com^$third-party
 ||kisa-link.blok.link^$third-party
-||cdn.tynt.com^$script,third-party
 ||sophomoreclassicoriginally.com^$script,third-party

--- a/easylistspanish/easylistspanish_thirdparty.txt
+++ b/easylistspanish/easylistspanish_thirdparty.txt
@@ -16,3 +16,5 @@
 ||jsc.adgage.es^$third-party
 ||cdn.zxclan.com^$third-party
 ||kisa-link.blok.link^$third-party
+||cdn.tynt.com^$script,third-party
+||sophomoreclassicoriginally.com^$script,third-party


### PR DESCRIPTION
Filter for blocking the referrals after starting/pausing the video and/or clicking the provider button on [ver-television](https://www.ver-television.online/canal-26-en-vivo ).

Proposed filters: 
```
||cdn.tynt.com^$script,third-party
||sophomoreclassicoriginally.com^$script,third-party
```

Other possible option would be to block the script: `/s.js` I believe this script contains `cdn.tynt.com/tc.js` and `whos.amung.us`

Screenshots of the following situation:
[Screen record](https://vimeo.com/616018557/f078ed8996)