### PR TITLE
A: tmohentai.com [NSFW]

### DIFF
--- a/easylistspanish_adult/adult_specific_block.txt
+++ b/easylistspanish_adult/adult_specific_block.txt
@@ -29,3 +29,4 @@
 ||pinklabel.com/tools/live-banners^$subdocument,domain=poringa.net
 ||blogspot.com/-*/BNO-300x250.gif^$domain=erospanish.com
 ||imx.to/imx.php?
+/fro_ld$script,domain=tmohentai.com


### PR DESCRIPTION
Filter for blocking the specific script responsible for ads at [tmohentai](https://tmohentai.com/) [NSFW].

Proposed specific blocking filter : `/fro_ld$script,domain=tmohentai.com`
Other possible option would be the following script : `/nb/back_ld.php` but as the upper one initiate this one, i preferred to go with the first. 

Screenshot + Issue report: [Report](https://reports.adblockplus.org/7b0055f1-0967-489e-ae81-a8cf13aaeb95#tab=screenshot)