### PR TITLE
A: cuevana-3.wtf

### DIFF
--- a/easylistspanish/easylistspanish_specific_block.txt
+++ b/easylistspanish/easylistspanish_specific_block.txt
@@ -624,3 +624,5 @@ $third-party,xmlhttprequest,domain=animeflv.net|descargasnsn.com|divxatope.com|d
 /popup-maker/$script,domain=diariotextual.com
 ||rontent.powvibeo.cc^$popup,script
 ||centent.slreamplay.cc^$popup,script
+||caunuscoagel.com$script,third-party
+||clickgate07.biz$script,third-party

--- a/easylistspanish/easylistspanish_specific_hide.txt
+++ b/easylistspanish/easylistspanish_specific_hide.txt
@@ -968,3 +968,4 @@ kairosweb.com##.spu-bg
 kairosweb.com##.spu-box
 poki.com##div[class^="Advertisement__AdvertisementContainer"]
 skdesu.com##.code-block[style^="margin: 20px auto;"]
+cuevana-3.wtf###block-3


### PR DESCRIPTION
Filters for blocking ads at the subpage [Cuevana - subapge]( https://www.cuevana-3.wtf/ver-episodio-1/el-juego-del-calamar-1x8/) and hide an ad at the main and subpages [Cuevana - main](https://www.cuevana-3.wtf/)

Proposed filters for the following [IR](https://reports.adblockplus.org/270ca3db-d5c7-4a8d-90c0-1457e442b6a4#tab=screenshot) : 
```
||clickgate07.biz$script,third-party
||caunuscoagel.com$script,third-party
```

Proposed filter for the main page: `cuevana-3.wtf###block-3`

Screenshots: 
<img width="1435" alt="Screenshot 2021-09-27 at 23 06 46" src="https://user-images.githubusercontent.com/65717387/135010776-eaae3967-7c4b-4e6d-91a8-44d084d95e4d.png">
<img width="1440" alt="Screenshot 2021-09-27 at 23 08 19" src="https://user-images.githubusercontent.com/65717387/135010787-5f1d9f3c-3b95-4725-9556-01e772852506.png">


