### PR TITLE
A: hitfm.es

### DIFF
--- a/easylistspanish/easylistspanish_allowlist_general_hide.txt
+++ b/easylistspanish/easylistspanish_allowlist_general_hide.txt
@@ -2,3 +2,4 @@ mejoratuescuela.org#@#.container-ads
 itsoft.es#@#.ad-full
 itsoft.es#@#.ad-col
 xunta.gal#@#div[id^="anuncio"]
+hitfm.es#@#.publi


### PR DESCRIPTION
Exception filter for [hitfm](https://www.hitfm.es/hit-30/), we received an email with a request to fix the webpage. 

After analyse, the filter that is breaking the webpage was this one: `##.publi `

For that reason our proposal is the allowing filter: `hitfm.es#@#.publi`
Another option would be to delete the filter `##.publi ` as it could break another webpages.

Screenshot:
<img width="1440" alt="Screenshot 2021-09-28 at 07 54 10" src="https://user-images.githubusercontent.com/65717387/135074144-a55ee604-f594-45f1-88d5-c590fdd694ba.png">

