### PR TITLE
A: albumoftheyear.org

### DIFF
--- a/easylistspanish/easylistspanish_specific_hide.txt
+++ b/easylistspanish/easylistspanish_specific_hide.txt
@@ -968,3 +968,4 @@ kairosweb.com##.spu-bg
 kairosweb.com##.spu-box
 poki.com##div[class^="Advertisement__AdvertisementContainer"]
 skdesu.com##.code-block[style^="margin: 20px auto;"]
+albumoftheyear.org##[class^="adTag"]


### PR DESCRIPTION
Filters for hiding placeholders at [albumoftheyear](https://www.albumoftheyear.org/album/339855-silk-sonic-an-evening-with-silk-sonic.php). 

Proposed filter: `albumoftheyear.org##[class^="adTag"]` it can also be more generic `##[class^="adTag"]`
I've used this filter due to two placeholders : adTag-two, adTag-three

Screenshot: 
<img width="1437" alt="Screenshot 2021-09-28 at 08 33 27" src="https://user-images.githubusercontent.com/65717387/135079105-b5da1783-88cf-4eac-9834-52ebe0eb6742.png">
