### PR TITLE
A: newsearnmoney.com

### DIFF
--- a/easylistspanish/easylistspanish_specific_block.txt
+++ b/easylistspanish/easylistspanish_specific_block.txt
@@ -625,3 +625,4 @@ $third-party,xmlhttprequest,domain=animeflv.net|descargasnsn.com|divxatope.com|d
 ||rontent.powvibeo.cc^$popup,script
 ||centent.slreamplay.cc^$popup,script
 ||maholinoticed.com^$script
+||newsearnmoney.com/*/popup.js


### PR DESCRIPTION
Filter for blocking popup at [newsearnmoney](https://newsearnmoney.com/lXDwy?cep=*&lptoken=*&utm_content=*&utm_term=*&utm_source=*&utm_campaign=*&utm_medium=*&ref=*&cost=*&eid=*)

Proposed filter: `||newsearnmoney.com/*/popup.js`

Screenshot: 
<img width="1439" alt="Screenshot 2021-09-28 at 08 41 41" src="https://user-images.githubusercontent.com/65717387/135081667-a04c4fbe-d168-4cbb-8e12-a9ee087348ce.png">

