### PR TITLE
A: animeflv.net

### DIFF
--- a/easylistspanish/easylistspanish_specific_block.txt
+++ b/easylistspanish/easylistspanish_specific_block.txt
@@ -626,3 +626,4 @@ $third-party,xmlhttprequest,domain=animeflv.net|descargasnsn.com|divxatope.com|d
 ||centent.slreamplay.cc^$popup,script
 /imagenespublicidad/$image,domain=alcalorpolitico.com
 ||maholinoticed.com^$script
+||unpkg.com/*/videojs_5.vast.vpaid$script


### PR DESCRIPTION
Filter for blocking the ad inside the video after pressing play at the last proxy (5) [animeflv.net](https://www3.animeflv.net/ver/kobayashisan-chi-no-maid-dragon-s-12)

Proposed filter: 
`||unpkg.com/*/videojs_5.vast.vpaid$script`

I believe it's also a subdomain of the following PR:
#
https://github.com/easylist/easylistspanish/pull/169

IR (scressnshot) - [Report](https://reports.adblockplus.org/2d7dd03e-c659-4b40-a2a3-72d00c5e357b#tab=screenshot)