### PR TITLE
A: gnula.cc

### DIFF
--- a/easylistspanish/easylistspanish_adservers.txt
+++ b/easylistspanish/easylistspanish_adservers.txt
@@ -258,3 +258,5 @@
 ||dogiedimepupae.com^$third-party
 ||sunwardamoraic.com^$third-party
 ||bluntabsolutionoblique.com^$third-party
+||jawholeminable.com^$third-party
+||writeratic.xyz^$third-party


### PR DESCRIPTION
Filter for blocking adservers responsible for popup ads at [gnula](https://www.gnula.cc/ver-serie/twin-peaks-1990-hd-online/)

Proposed filters: 
```
||jawholeminable.com^$third-party
||writeratic.xyz^$third-party
```

Screenshots: 
![9f8610dc-a095-4522-870c-9a95253462ee](https://user-images.githubusercontent.com/65717387/135850930-52d413b6-d97f-4f87-92d9-922117ac45b7.png)
<img width="1440" alt="Screenshot 2021-10-04 at 09 13 39" src="https://user-images.githubusercontent.com/65717387/135850826-9fd7ee72-5932-4f85-abfc-8eaa8c9b230c.png">

