### PR TITLE
A: serieslatinoamerica.tv

### DIFF
--- a/easylistspanish/easylistspanish_adservers.txt
+++ b/easylistspanish/easylistspanish_adservers.txt
@@ -258,3 +258,4 @@
 ||dogiedimepupae.com^$third-party
 ||sunwardamoraic.com^$third-party
 ||bluntabsolutionoblique.com^$third-party
+||raccrocpestful.com^$third-party


### PR DESCRIPTION
Filter for blocking adserver responsible for ads at [serieslatinoamerica](https://serieslatinoamerica.tv/episodio/invincible-1x2/) , ZPlayer proxy. 

Proposed filter: `||raccrocpestful.com^$third-party`

Screenshot: 
<img width="1440" alt="Screenshot 2021-10-04 at 09 49 10" src="https://user-images.githubusercontent.com/65717387/135854920-b02e583c-360e-406f-91de-236a7a35ad42.png">

