### PR TITLE
A: mundosexanuncio.com(NFSW)

### DIFF
--- a/easylistspanish/easylistspanish_general_hide.txt
+++ b/easylistspanish/easylistspanish_general_hide.txt
@@ -212,6 +212,7 @@
 ##div[class^="publicHoriz"]
 ##div[id^="M"][id*="Composite"]
 ##div[id^="anuncio"]
+##img[alt*="Publicidad"]
 ! Anti-Adblock
 ###deadblocker_dialog
 ##.adblockInfo


### PR DESCRIPTION
Filter for hiding the ad at the header on [mundosexanuncio](https://www.mundosexanuncio.com/contactos-lesbianas/lidia-masajista-bisexual-espanola-76161191)

Proposed filter: `##img[alt*="Publicidad"]` I believe it can be a general one, but i'm not sure, if we do need to be more specific just let me know.

Screenshot:
<img width="938" alt="Screenshot 2021-10-05 at 10 11 29" src="https://user-images.githubusercontent.com/65717387/136029902-0a27709f-331c-4ce4-9dc1-b3493b4c17e3.png">
 
