### PR TITLE
A: gnula.se

### DIFF
--- a/easylistspanish/easylistspanish_adservers.txt
+++ b/easylistspanish/easylistspanish_adservers.txt
@@ -258,3 +258,5 @@
 ||dogiedimepupae.com^$third-party
 ||sunwardamoraic.com^$third-party
 ||bluntabsolutionoblique.com^$third-party
+||travelingturtleharmonious.com^$third-party
+||ultimowraxle.com^$third-party


### PR DESCRIPTION
Filters to block adservers at [gnula.se](https://gnula.se/) 

Proposed filters: 
```
||travelingturtleharmonious.com^$third-party
||ultimowraxle.com^$third-party
```

How to reproduce : click at any movie, you are going to be redirected. 
when it comes to the filter `||ultimowraxle.com^$third-party` it should be responsible for popup messages, that are not showing up, but you can check the messages coming in here: 
<img width="206" alt="Screenshot 2021-10-06 at 12 27 03" src="https://user-images.githubusercontent.com/65717387/136234871-24026f21-1ec0-4113-bcc0-67653ddaa72c.png">

