### PR TITLE
A: pandrama.cc

### DIFF
--- a/easylistspanish/easylistspanish_adservers.txt
+++ b/easylistspanish/easylistspanish_adservers.txt
@@ -258,3 +258,4 @@
 ||dogiedimepupae.com^$third-party
 ||sunwardamoraic.com^$third-party
 ||bluntabsolutionoblique.com^$third-party
+||c6a32ec500.0750a40b0d.com^$third-party


### PR DESCRIPTION
Filter for blocking adserver responsible for popup message at [pandrama](https://pandrama.cc/ver-capitulos-online/leverage-capitulo-1/)

Proposed filter: `||c6a32ec500.0750a40b0d.com^$third-party`

issue Report [screenshot](https://reports.adblockplus.org/249d4ad0-776b-44f0-96b3-e6401767eca4#tab=screenshot)