### PR TITLE
A: slidesgo.com

### DIFF
--- a/easylistspanish/easylistspanish_specific_hide.txt
+++ b/easylistspanish/easylistspanish_specific_hide.txt
@@ -974,3 +974,5 @@ cuevana-3.wtf###block-3
 alcalorpolitico.com##div[id^="Bannerprincipal"]
 elcontribuyente.mx##a[onclick*="Publicidad"]
 elcontribuyente.mx#?#div:-abp-has(a[title="Clickio"])
+slidesgo.com##div[id^="list_ads"]
+slidesgo.com##div[id^="article_ads"]


### PR DESCRIPTION
Filters for hiding placeholders at [main page](https://slidesgo.com/es) and [subdomain](https://slidesgo.com/es/tema/pegatinas-de-halloween#search-Halloween&position-2&results-24
)

proposed filters:
```
slidesgo.com##div[id^="list_ads"]
slidesgo.com##div[id^="article_ads"]
```

Screenshots:
<img width="441" alt="Screenshot 2021-10-07 at 00 10 14" src="https://user-images.githubusercontent.com/65717387/136315283-69c52201-4d3c-469e-94ab-9cbcad8ddb19.png">
<img width="1439" alt="Screenshot 2021-10-07 at 00 18 56" src="https://user-images.githubusercontent.com/65717387/136315308-20b3556b-cd13-4139-8b65-94d442662558.png">

