### PR TITLE
A: caracoltv.com

### DIFF
--- a/easylistspanish/easylistspanish_specific_hide.txt
+++ b/easylistspanish/easylistspanish_specific_hide.txt
@@ -978,3 +978,4 @@ puupnewsapp.com##[class*="code-block-"]
 monoschinos2.com##.info-tv
 monoschinos2.com##a[href^="https://zenkublocks.com"]
 cerebriti.com###barraAvisoAds
+caracoltv.com##[class^="GoogleDfpAd"]


### PR DESCRIPTION
Filter for hiding placeholder at [caracoltv](https://gol.caracoltv.com/)

Proposed filter : `caracoltv.com##[class^="GoogleDfpAd"]` - I could see some other similiar filters, on the other hand they were not covering everything. As they were general filters, maybe we could exclude 2 of they and make it more wider : `##[class^="GoogleDfpAd"]`

<img width="1440" alt="Screenshot 2021-10-15 at 10 00 16" src="https://user-images.githubusercontent.com/65717387/137491624-5e5dcc11-f01c-4626-bf34-9ea1787b92ad.png">

Screenshot: 
<img width="1440" alt="Screenshot 2021-10-15 at 10 00 31" src="https://user-images.githubusercontent.com/65717387/137491709-9355d799-7502-44f8-ba98-bbdeb5505c14.png">


