### PR TITLE
A: doramasmp4.com

### DIFF
--- a/easylistspanish/easylistspanish_adservers_popup.txt
+++ b/easylistspanish/easylistspanish_adservers_popup.txt
@@ -63,3 +63,4 @@
 ||lukomol.com^$popup,third-party
 ||shoveoccupiedinsult.com^$popup,third-party
 ||favouritesuitable.com^$popup,third-party
+||demotzincky.casa^$popup,third-party


### PR DESCRIPTION
Filter for blocking popup adserver at [doramasmp4](https://www31.doramasmp4.com/high-class-capitulo-13) while clicking play and pause in different proxy's.

Proposed filter: `||demotzincky.casa^$popup,third-party`

Screenshot:
<img width="1440" alt="Screenshot 2021-10-20 at 08 07 08" src="https://user-images.githubusercontent.com/65717387/138083730-f4ad288d-95bf-483d-b606-67bd7f4d96b3.png">
 