### PR TITLE
A: dontorrent.rip

### DIFF
--- a/easylistspanish/easylistspanish_specific_block.txt
+++ b/easylistspanish/easylistspanish_specific_block.txt
@@ -640,3 +640,4 @@ $third-party,xmlhttprequest,domain=animeflv.net|descargasnsn.com|divxatope.com|d
 ||cultergoy.com$script
 ||ckwlurries.com$script
 ||randallbesin.com^$script
+||startgaming.net$image,domain=dontorrent.rip


### PR DESCRIPTION
Filter for blocking images responsible for ads at [dontorrent](https://dontorrent.rip/)

Screenshot:
<img width="1397" alt="Screenshot 2021-10-26 at 07 19 33" src="https://user-images.githubusercontent.com/65717387/138859185-6b307d62-fdb6-4364-b23e-81eef36dd95b.png">

