### PR TITLE
gestion.pe

### DIFF
--- a/easylistspanish/easylistspanish_specific_hide.txt
+++ b/easylistspanish/easylistspanish_specific_hide.txt
@@ -1172,3 +1172,4 @@ pelicula.ws##section[style^="height:150px; width:100%; padding-bottom:0px;"]
 superluchas.com#?#h2:-abp-contains(Anuncio)
 univision.com#?#div:-abp-has(>span:-abp-contains(Publicidad))
 valoraanalitik.com#?#label:-abp-contains(Publicidad)
+gestion.pe##[class$="_ads"]


### PR DESCRIPTION
https://gestion.pe/peru/covid-19-estado-de-emergencia-nacional-se-amplia-hasta-febrero-del-2022-nndc-noticia/

![image](https://user-images.githubusercontent.com/58596052/147232458-b5708130-1195-4fa1-b7eb-4157a8c42745.png)
