### PR TITLE
M: Update (move filter to EL as generic)

### DIFF
--- a/easylistspanish/easylistspanish_specific_hide.txt
+++ b/easylistspanish/easylistspanish_specific_hide.txt
@@ -1082,7 +1082,6 @@ wizcase.com###sidebar-top-vendors
 baratos.com###ue_popups
 ettv.unblockninja.com###vpnvpn
 radioexito.com.ar##.Estilo1
-bluradio.com,caracoltv.com,shock.co##.GoogleDfpAd-Float
 coin360.com##.StickyCorner
 coin360.com##.TopLeaderboard
 elcolombiano.com##.Widgetsliderintelecto


### PR DESCRIPTION
Request to move below filter to EasyList as generic, so it could more sites.

Reference PR to add filter as generic to EasyList and avoid redundancy: https://github.com/easylist/easylist/pull/12986

Filter: 
`bluradio.com,caracoltv.com,shock.co##.GoogleDfpAd-Float`