### PR TITLE
A: `futbolme.com`

### DIFF
--- a/easylistspanish/easylistspanish_specific_hide.txt
+++ b/easylistspanish/easylistspanish_specific_hide.txt
@@ -1,3 +1,4 @@
+futbolme.com###headeradd
 norteenlinea.com###Mod375
 norteenlinea.com###Mod427
 norteenlinea.com###Mod450
@@ -255,6 +256,7 @@ todoblaugrana.com##div[style*="width: 300px; height: 250px;"]
 diariocritico.com##div[style^="width: 300px; height: 250px;"]
 diariocritico.com##div[style^="width: 300px; height: 600px;"]
 lectortmo.org##iframe[style*="z-index: 2147483647"]
+futbolme.com##div[style*="z-index: 9999"]
 diariodelaribera.net##img[alt^="Banner"]
 expansion.com##img[class="ue-c-widget__sponsor"]
 planbnoticias.com.ar##img[height="200"]


### PR DESCRIPTION
Hi, please add these specific filter to correct the page layout and remove empty spaces left after ads were removed:

- `futbolme.com###headeradd` 
![image](https://user-images.githubusercontent.com/33602691/217487544-8e781ac9-4c85-41b5-ab1b-9566fb5829bd.png)


- `futbolme.com##div[style*="z-index: 9999"]`
![image](https://user-images.githubusercontent.com/33602691/217487736-343d6d94-1607-4f14-aa04-a9d5fc9aef7b.png)

Please do add both filters as if only the first one is added the nav bar its covered and would look like this:
![image](https://user-images.githubusercontent.com/33602691/217488033-1d858faf-4d26-4675-868c-497b7699fa05.png)

Thanks a lot in advance 
