### PR TITLE
M: atlantico.net

### DIFF
--- a/easylistspanish/easylistspanish_specific_hide.txt
+++ b/easylistspanish/easylistspanish_specific_hide.txt
@@ -912,6 +912,7 @@ mediamarkt.es##[data-test="mms-product-card"]:has([data-test="mms-plp-presented"
 as.com#?#.s.s--v:-abp-has(span:-abp-contains(OFRECIDO POR))
 atlantico.net,laregion.es#?#.recirculation:-abp-contains(Contenido patrocinado)
 diarios-argentinos.com#?#.wide-content:-abp-has(h1:-abp-contains(Publicidad))
+eldiariony.com,laopinion.com,laraza.com#?#.module--external:-abp-contains(Contenido Patrocinado)
 elespectador.com#?#.Block:-abp-has(.Title_section:-abp-contains(Contenido patrocinado))
 elespectador.com#?#.Card:-abp-has(.Card-Section.Section:-abp-contains(Contenido patrocinado))
 elquindiano.com,laboyanos.com#?#span:-abp-contains(PUBLICIDAD)

--- a/easylistspanish/easylistspanish_specific_hide.txt
+++ b/easylistspanish/easylistspanish_specific_hide.txt
@@ -910,6 +910,7 @@ cuencanews.es##td[class*="id_publi_"]:has(img[alt="publicidad"])
 ! Advanced element hiding rules for Adblock Plus
 mediamarkt.es##[data-test="mms-product-card"]:has([data-test="mms-plp-presented"])
 as.com#?#.s.s--v:-abp-has(span:-abp-contains(OFRECIDO POR))
+atlantico.net,laregion.es#?#.recirculation:-abp-contains(Contenido patrocinado)
 diarios-argentinos.com#?#.wide-content:-abp-has(h1:-abp-contains(Publicidad))
 elespectador.com#?#.Block:-abp-has(.Title_section:-abp-contains(Contenido patrocinado))
 elespectador.com#?#.Card:-abp-has(.Card-Section.Section:-abp-contains(Contenido patrocinado))


### PR DESCRIPTION
Adding an ABP compatible versions for two existing filters, so ABP users can also benefit from the filter.
`atlantico.net,laregion.es##.recirculation:has-text(Contenido patrocinado)`
`eldiariony.com,laopinion.com,laraza.com##.module--external:has-text(Contenido Patrocinado)`

example page `https://www.atlantico.net/mundo/maduro-declara-inocente-tribunal-nueva_1_20260105-4113840.html`